### PR TITLE
bugfix/WY-213 disable functional cookie toggle

### DIFF
--- a/complianz-gdpr-premium/templates/cookiebanner.php
+++ b/complianz-gdpr-premium/templates/cookiebanner.php
@@ -85,7 +85,8 @@
 										data-category="cmplz_functional"
 										class="cmplz-consent-checkbox cmplz-functional"
 										size="40"
-										value="1"/>
+										value="1"
+										disabled />
 								<span class="cmplz-slider cmplz-round"></span>
 							</div>
 							<span class="cmplz-label" tabindex="0">{category_functional}</span>


### PR DESCRIPTION
Functional cookies are always on, so disable toggle to prevent visual errors with the setting