### PR TITLE
WY-684 provide inline styles to hds wp

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -11,6 +11,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  */
 require_once get_template_directory() . '/setup/loader.php';
+spl_autoload_register( __NAMESPACE__ . '\\helsinki_class_autoloader' );
+
 add_action('after_setup_theme', 'helsinki_load_files', 0);
 
 /**

--- a/setup/assets.php
+++ b/setup/assets.php
@@ -149,69 +149,24 @@ function helsinki_script_localization() {
 /**
   * Theme schemes
   */
-function helsinki_set_current_scheme( string $scheme ) {
-	$valid = helsinki_customizer_choices_style_schemes();
-	if ( ! isset($valid[$scheme]) ) {
-		$scheme = helsinki_default_scheme();
-	}
-
-	add_filter(
-		'helsinki_scheme',
-		function() use ($scheme) {
-			return $scheme;
-		}
+function helsinki_set_current_scheme( string $scheme ): void {
+	trigger_error(
+		__FUNCTION__ . '() is deprecated. Use helsinki_set_current_scheme action instead.',
+		E_USER_DEPRECATED
 	);
 
-	add_action(
-		'wp_head',
-		function() use ($scheme) {
-			helsinki_scheme_root_styles($scheme);
-		}
-	);
+	error_log( print_r( debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 ), true ) );
 
-	add_action(
-		'admin_head',
-		function() use ($scheme) {
-			helsinki_scheme_root_styles($scheme);
-		}
-	);
+	do_action( 'helsinki_set_current_scheme', $scheme );
 }
 
-function helsinki_scheme_root_styles( string $scheme ) {
-	$config = helsinki_colors( $scheme );
-
-	$colors = apply_filters(
-		'helsinki_scheme_root_styles_colors',
-		array(
-			'--primary-color' => $config['primary']['color'] ?? '--color-' . $scheme,
-			'--primary-color-light' => $config['primary']['light'] ?? '--color-' . $scheme . '-light',
-			'--primary-color-medium' => $config['primary']['medium'] ?? '--color-' . $scheme . '-medium-light',
-			'--primary-color-dark' => $config['primary']['dark'] ?? '--color-' . $scheme . '-dark',
-			'--primary-content-color' => $config['primary']['content'] ?? '--color-' . $scheme . '-content',
-			'--primary-content-secondary-color' => $config['primary']['content-secondary'] ?? '--color-' . $scheme . '-content-secondary',
-			'--secondary-color' => $config['secondary'] ?? '',
-			'--secondary-content-color' => $config['secondary-content'] ?? '',
-			'--accent-color' => $config['accent'] ?? '',
-		),
-		$scheme,
-		$config
+function helsinki_scheme_root_styles( string $scheme ): void {
+	trigger_error(
+		__FUNCTION__ . '() is deprecated. Get scheme root styles via helsinki_scheme_root_styles filter.',
+		E_USER_DEPRECATED
 	);
 
-	$use_hex = apply_filters(
-		'helsinki_scheme_root_styles_use_hex',
-		! empty( sanitize_hex_color( $colors['--primary-color'] ) )
-	);
-
-	$properties = array();
-	foreach ( $colors as $key => $value ) {
-		$properties[] = sprintf(
-			'%s: %s;',
-			esc_attr($key),
-			$use_hex ? sanitize_hex_color( $value ) : 'var(' . esc_attr($value) . ')'
-		);
-	}
-
-	echo '<style>:root {' . implode( ' ', $properties ) . '}</style>';
+	error_log( print_r( debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS, 1 ), true ) );
 }
 
 function helsinki_scheme_body_class( $classes ) {

--- a/setup/loader.php
+++ b/setup/loader.php
@@ -1,6 +1,37 @@
 <?php
 
 /**
+ * Autoloader
+ */
+function helsinki_class_autoloader( $class ) {
+	$namespace = 'CityOfHelsinki\WordPress\Helsinki\Theme';
+
+	if ( false === stripos( $class, $namespace ) ) {
+		return;
+	}
+
+	$parts = array_filter(
+		explode(
+			DIRECTORY_SEPARATOR,
+			str_replace(
+				[$namespace, '\\'],
+				['', DIRECTORY_SEPARATOR],
+				$class
+			)
+		)
+	);
+
+	$class = array_pop( $parts );
+	$class = 'class-' . str_replace( '_', '-', strtolower( $class ) );
+
+	helsinki_include_file(
+		get_template_directory(),
+		helsinki_build_file_path( ...array_map( 'strtolower', $parts ) ),
+		$class
+	);
+}
+
+/**
  * Include theme files
  */
 function helsinki_load_files(): void {

--- a/setup/scheme/class-theme-scheme-hooks.php
+++ b/setup/scheme/class-theme-scheme-hooks.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace CityOfHelsinki\WordPress\Helsinki\Theme\Setup\Scheme;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Theme_Scheme_Hooks
+{
+	protected Theme_Scheme $scheme;
+	protected Theme_Scheme_Styles $styles;
+
+	public function __construct(
+		Theme_Scheme $scheme,
+		Theme_Scheme_Styles $styles
+	) {
+		$this->scheme = $scheme;
+		$this->styles = $styles;
+	}
+
+	public function set_scheme( string $scheme ): void
+	{
+		$this->scheme->set_current( $scheme );
+	}
+
+	public function current_scheme(): string
+	{
+		return $this->scheme->current();
+	}
+
+	public function root_styles(): string
+	{
+		return $this->styles->root_styles( $this->scheme );
+	}
+
+	public function print_inline_styles(): void
+	{
+		printf( '<style>%s</style>', $this->root_styles() );
+	}
+}

--- a/setup/scheme/class-theme-scheme-styles.php
+++ b/setup/scheme/class-theme-scheme-styles.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace CityOfHelsinki\WordPress\Helsinki\Theme\Setup\Scheme;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Theme_Scheme_Styles
+{
+	protected array $colors;
+
+	public function __construct( array $colors )
+	{
+		$this->colors = $colors;
+	}
+
+	public function root_styles( Theme_Scheme $scheme ): string
+	{
+		return sprintf( ':root {%s}', implode( ' ' ,
+			$this->colors_to_css_properties( $this->setup_colors( $scheme ) )
+		) );
+	}
+
+	private function colors_to_css_properties( array $colors ): array
+	{
+		$use_hex = $this->use_hex( $colors );
+
+		$properties = array();
+		foreach ( $colors as $key => $value ) {
+			$properties[] = sprintf(
+				'%s: %s;',
+				\esc_attr($key),
+				$use_hex ? \sanitize_hex_color( $value ) : 'var(' . \esc_attr($value) . ')'
+			);
+		}
+
+		return $properties;
+	}
+
+	private function use_hex( array $colors ): bool
+	{
+		return \apply_filters(
+			'helsinki_scheme_root_styles_use_hex',
+			! empty( \sanitize_hex_color( $colors['--primary-color'] ) )
+		);
+	}
+
+	private function setup_colors( Theme_Scheme $scheme ): array
+	{
+		$config = $this->color_config( $scheme );
+
+		return \apply_filters(
+			'helsinki_scheme_root_styles_colors',
+			array(
+				'--primary-color' => $config['primary']['color']
+					?? '--color-' . $scheme->current(),
+				'--primary-color-light' => $config['primary']['light']
+					?? '--color-' . $scheme->current() . '-light',
+				'--primary-color-medium' => $config['primary']['medium']
+					?? '--color-' . $scheme->current() . '-medium-light',
+				'--primary-color-dark' => $config['primary']['dark']
+					?? '--color-' . $scheme->current() . '-dark',
+				'--primary-content-color' => $config['primary']['content']
+					?? '--color-' . $scheme->current() . '-content',
+				'--primary-content-secondary-color' => $config['primary']['content-secondary']
+					?? '--color-' . $scheme->current() . '-content-secondary',
+				'--secondary-color' => $config['secondary']
+					?? '',
+				'--secondary-content-color' => $config['secondary-content']
+					?? '',
+				'--accent-color' => $config['accent']
+					?? '',
+			),
+			$scheme->current(),
+			$config
+		);
+	}
+
+	private function color_config( Theme_Scheme $scheme ): array
+	{
+		$colors = \apply_filters( 'helsinki_colors', $this->colors );
+
+		return $colors[$scheme->current()] ?? $colors[$scheme->default()];
+	}
+}

--- a/setup/scheme/class-theme-scheme.php
+++ b/setup/scheme/class-theme-scheme.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types = 1);
+
+namespace CityOfHelsinki\WordPress\Helsinki\Theme\Setup\Scheme;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class Theme_Scheme
+{
+	protected string $current;
+	protected string $default;
+	protected array $options;
+
+	public function __construct( array $options, string $default )
+	{
+		$this->options = $options;
+		$this->default = $default;
+		$this->current = $default;
+	}
+
+	public function set_current( string $scheme ): void
+	{
+		if ( $scheme ) {
+			$this->validate_scheme( $scheme );
+			$this->current = $scheme;
+		}
+	}
+
+	public function current(): string
+	{
+		return $this->current;
+	}
+
+	public function default(): string
+	{
+		return \apply_filters( 'helsinki_default_scheme', $this->default );
+	}
+
+	private function validate_scheme( string $scheme ): void
+	{
+		if ( ! isset( $this->options[$scheme] ) ) {
+			throw new \InvalidArgumentException( sprintf(
+				_x( '%s is not a valid theme scheme.', 'Helsinki theme scheme validation exception', 'helsinki-universal' ),
+				$scheme
+			) );
+		}
+	}
+}


### PR DESCRIPTION
Relates to [Two notices after activating the plugin](https://github.com/City-of-Helsinki/wordpress-helfi-hds-wp/issues/230)

### Added

- Class autoloader for namespace `CityOfHelsinki\WordPress\Helsinki\Theme`
- class `Theme_Scheme`
- class `Theme_Scheme_Styles`
- class `Theme_Scheme_Hooks`

### Changed

- Use `Theme_Scheme_Hooks` class to provide current scheme and inline root styles

### Deprecations

- `helsinki_set_current_scheme()`  => use `helsinki_set_current_scheme` action
- `helsinki_scheme_root_styles()`  => use `helsinki_scheme_root_styles` filter